### PR TITLE
Optimize secp256r1 202306

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ TARGET_PREFIX ?= $(TARGET)-
 CC := $(TARGET_PREFIX)gcc
 LD := $(TARGET_PREFIX)ld
 OBJCOPY := $(TARGET_PREFIX)objcopy
-CFLAGS := -fPIC -O3 -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/libc -I deps -I deps/ckb-c-stdlib/molecule -I c -I build -I deps/secp256k1/src -I deps/secp256k1 -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
+CFLAGS := -fPIC -O3 -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/libc -I deps -I deps/ckb-c-stdlib/molecule -I c -I build -I deps/secp256k1/src -I deps/secp256k1 -Wall -Wno-error -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections
 SECP256K1_SRC := deps/secp256k1/src/ecmult_static_pre_context.h
 
-CFLAGS_MBEDTLS := -fPIC -Os -fno-builtin-printf -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/molecule -I deps/ckb-c-stdlib/libc -I deps/mbedtls/include -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
+CFLAGS_MBEDTLS := -fPIC -Os -fno-builtin-printf -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/molecule -I deps/ckb-c-stdlib/libc -I deps/mbedtls/include -Wall -Wno-error -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
 LDFLAGS_MBEDTLS := -Wl,-static -Wl,--gc-sections
 PASSED_MBEDTLS_CFLAGS := -Os -fPIC -nostdinc -nostdlib -DCKB_DECLARATION_ONLY -I ../../ckb-c-stdlib/libc -fdata-sections -ffunction-sections
 
@@ -28,7 +28,7 @@ MOLC_VERSION := 0.7.0
 DOCKER_USER := $(shell id -u):$(shell id -g)
 DOCKER_EXTRA_FLAGS ?=
 # docker pull nervos/ckb-riscv-gnu-toolchain:gnu-bionic-20191012
-BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:aae8a3f79705f67d505d1f1d5ddc694a4fd537ed1c7e9622420a470d59ba2ec3
+BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain:gnu-focal-20230214
 CKB-DEBUGGER := ckb-debugger
 
 all: build/htlc build/secp256k1_blake2b_sighash_all_lib.so build/or build/simple_udt build/secp256k1_blake2b_sighash_all_dual build/and build/open_transaction build/rsa_sighash_all blst-demo deps/libecc-riscv-optimized build/secp256r1_blake160_sighash_all build/secp256r1_bench
@@ -75,7 +75,7 @@ build/ll_u256_mont_mul: build/ll_u256_mont-riscv64.o build/ll_u256_mont_mul.o
 
 # Benchmark for secp256r1 signature verification based on a older libecc from lay2dev, with some improvements
 build/secp256r1_bench: c/secp256r1_blake160_sighash_bench.c libecc-riscv-optimized
-	$(CC) $(CFLAGS) $(CFLAGS_LINK_TO_LIBECC_OPTIMIZED) $(LDFLAGS) -o $@ c/secp256r1_bench.c ${LIBECC_OPTIMIZED_FILES}
+	$(CC) $(CFLAGS) $(CFLAGS_LINK_TO_LIBECC_OPTIMIZED) $(LDFLAGS) -o $@ c/secp256r1_bench.c ${LIBECC_OPTIMIZED_FILES} $(shell $(CC) --print-search-dirs | sed -n '/install:/p' | sed 's/install:\s*//g')libgcc.a
 	cp $@ $@.debug
 	$(OBJCOPY) --strip-debug --strip-all $@ $@.stripped
 

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ build/secp256r1_bench: c/secp256r1_blake160_sighash_bench.c libecc-riscv-optimiz
 	cp $@ $@.debug
 	$(OBJCOPY) --strip-debug --strip-all $@ $@.stripped
 
+secp256r1_bench-via-docker:
+	docker run --user ${DOCKER_USER} --rm -v `pwd`:/code ${BUILDER_DOCKER} bash -c "cd /code && make build/secp256r1_bench"
+
 # This is a lock script
 build/secp256r1_blake160_sighash_all: c/secp256r1_blake160_sighash_all.c c/common.h libecc-riscv-optimized
 	$(CC) $(CFLAGS) $(CFLAGS_LINK_TO_LIBECC_OPTIMIZED) $(LDFLAGS) -o $@ c/secp256r1_blake160_sighash_all.c c/common.h ${LIBECC_OPTIMIZED_FILES}

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ TARGET_PREFIX ?= $(TARGET)-
 CC := $(TARGET_PREFIX)gcc
 LD := $(TARGET_PREFIX)ld
 OBJCOPY := $(TARGET_PREFIX)objcopy
-CFLAGS := -fPIC -O3 -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/libc -I deps -I deps/ckb-c-stdlib/molecule -I c -I build -I deps/secp256k1/src -I deps/secp256k1 -Wall -Wno-error -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
+CFLAGS := -fPIC -O3 -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/libc -I deps -I deps/ckb-c-stdlib/molecule -I c -I build -I deps/secp256k1/src -I deps/secp256k1 -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections
 SECP256K1_SRC := deps/secp256k1/src/ecmult_static_pre_context.h
 
-CFLAGS_MBEDTLS := -fPIC -Os -fno-builtin-printf -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/molecule -I deps/ckb-c-stdlib/libc -I deps/mbedtls/include -Wall -Wno-error -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
+CFLAGS_MBEDTLS := -fPIC -Os -fno-builtin-printf -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/ckb-c-stdlib -I deps/ckb-c-stdlib/molecule -I deps/ckb-c-stdlib/libc -I deps/mbedtls/include -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
 LDFLAGS_MBEDTLS := -Wl,-static -Wl,--gc-sections
 PASSED_MBEDTLS_CFLAGS := -Os -fPIC -nostdinc -nostdlib -DCKB_DECLARATION_ONLY -I ../../ckb-c-stdlib/libc -fdata-sections -ffunction-sections
 
@@ -28,7 +28,7 @@ MOLC_VERSION := 0.7.0
 DOCKER_USER := $(shell id -u):$(shell id -g)
 DOCKER_EXTRA_FLAGS ?=
 # docker pull nervos/ckb-riscv-gnu-toolchain:gnu-bionic-20191012
-BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain:gnu-focal-20230214
+BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:aae8a3f79705f67d505d1f1d5ddc694a4fd537ed1c7e9622420a470d59ba2ec3
 CKB-DEBUGGER := ckb-debugger
 
 all: build/htlc build/secp256k1_blake2b_sighash_all_lib.so build/or build/simple_udt build/secp256k1_blake2b_sighash_all_dual build/and build/open_transaction build/rsa_sighash_all blst-demo deps/libecc-riscv-optimized build/secp256r1_blake160_sighash_all build/secp256r1_bench
@@ -75,7 +75,7 @@ build/ll_u256_mont_mul: build/ll_u256_mont-riscv64.o build/ll_u256_mont_mul.o
 
 # Benchmark for secp256r1 signature verification based on a older libecc from lay2dev, with some improvements
 build/secp256r1_bench: c/secp256r1_blake160_sighash_bench.c libecc-riscv-optimized
-	$(CC) $(CFLAGS) $(CFLAGS_LINK_TO_LIBECC_OPTIMIZED) $(LDFLAGS) -o $@ c/secp256r1_bench.c ${LIBECC_OPTIMIZED_FILES} $(shell $(CC) --print-search-dirs | sed -n '/install:/p' | sed 's/install:\s*//g')libgcc.a
+	$(CC) $(CFLAGS) $(CFLAGS_LINK_TO_LIBECC_OPTIMIZED) $(LDFLAGS) -o $@ c/secp256r1_bench.c ${LIBECC_OPTIMIZED_FILES}
 	cp $@ $@.debug
 	$(OBJCOPY) --strip-debug --strip-all $@ $@.stripped
 

--- a/tools/secp256r1-bench.sh
+++ b/tools/secp256r1-bench.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+top_dir="$(dirname "$script_dir")"
+libecc_dir="$top_dir/deps/libecc-riscv-optimized"
+
+cd "$libecc_dir"
+
+print_separator() {
+  echo "--------------------------------------------"
+}
+
+current="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$current" == "HEAD" ]]; then
+  current="$(git rev-parse HEAD)"
+fi
+
+reset_git_branch() {
+  echo "Resetting git commit"
+  git checkout "$current"
+}
+
+trap reset_git_branch EXIT INT TERM
+
+while [[ "$(git rev-parse HEAD)" != "$(git rev-parse 6a56c83fb0e264268b0486ea58ea1753a16aa699^)" ]]; do
+  git -c advice.detachedHead=false checkout HEAD^
+  if ! make -C "$top_dir" secp256r1_bench-via-docker 2>/dev/null >/dev/null; then
+    echo "make -C "$top_dir" secp256r1_bench-via-docker failed"
+    exit 1
+  fi
+  make -C "$top_dir" run-secp256r1-bench
+  print_separator
+done


### PR DESCRIPTION
The script `secp256r1-bench.sh` may be use to obtain show performance improvement.

Here is a summary of the respective improvement of cycle consumption of each commits in the libecc repo.


```
~/Workspace/ckb-miscellaneous-scripts/deps/libecc-riscv-optimized  ‹optimize-secp256r1-202306› $  ../../tools/secp256r1-bench.sh
--------------------------------------------

Note: switching to 'HEAD^'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 6b5292f make wclz faster by return earlier
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 7959899(7.6M)
Transfer cycles: 15730(15.4K), running cycles: 7944169(7.6M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was 6b5292f make wclz faster by return earlier
HEAD is now at 83e603d remove redundant set_wlen in nn_mod_{add,sub}
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 8223488(7.8M)
Transfer cycles: 15726(15.4K), running cycles: 8207762(7.8M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was 83e603d remove redundant set_wlen in nn_mod_{add,sub}
HEAD is now at 1f2cd9f break as soon as remainder is zero in nn_modinv
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 8509781(8.1M)
Transfer cycles: 15738(15.4K), running cycles: 8494043(8.1M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was 1f2cd9f break as soon as remainder is zero in nn_modinv
HEAD is now at d84942d use memcpy and memset from ckb-c-stdlib
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 9000914(8.6M)
Transfer cycles: 15738(15.4K), running cycles: 8985176(8.6M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was d84942d use memcpy and memset from ckb-c-stdlib
HEAD is now at b6538a0 don't clean memory in set_wlen when new wlen is smaller
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 9043097(8.6M)
Transfer cycles: 15478(15.1K), running cycles: 9027619(8.6M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was b6538a0 don't clean memory in set_wlen when new wlen is smaller
HEAD is now at df4a485 don't copy when src and dst are identical in nn_cnd_{add,sub}
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 9168479(8.7M)
Transfer cycles: 15474(15.1K), running cycles: 9153005(8.7M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was df4a485 don't copy when src and dst are identical in nn_cnd_{add,sub}
HEAD is now at 640d39f short circuit in nn_cmp
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 9554565(9.1M)
Transfer cycles: 15474(15.1K), running cycles: 9539091(9.1M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was 640d39f short circuit in nn_cmp
HEAD is now at 4c8a233 remove a few checks
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 9942322(9.5M)
Transfer cycles: 15582(15.2K), running cycles: 9926740(9.5M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was 4c8a233 remove a few checks
HEAD is now at b5d897b make nn_cnd_sub nn_cnd_add faster on condition false
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 10625969(10.1M)
Transfer cycles: 15624(15.3K), running cycles: 10610345(10.1M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was b5d897b make nn_cnd_sub nn_cnd_add faster on condition false
HEAD is now at 6a56c83 Update
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 10919998(10.4M)
Transfer cycles: 15652(15.3K), running cycles: 10904346(10.4M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

--------------------------------------------

Previous HEAD position was 6a56c83 Update
HEAD is now at 8219ab5 Update
make: Entering directory '/home/e/Workspace/ckb-miscellaneous-scripts'
ckb-debugger --bin build/secp256r1_bench
start main...
signature verification succeeded

Run result: 0
Total cycles consumed: 10919998(10.4M)
Transfer cycles: 15652(15.3K), running cycles: 10904346(10.4M)
make: Leaving directory '/home/e/Workspace/ckb-miscellaneous-scripts'

Previous HEAD position was 8219ab5 Update
Switched to branch 'optimize-secp256r1-202306'
~/Workspace/ckb-miscellaneous-scripts/deps/libecc-riscv-optimized  ‹optimize-secp256r1-202306› $
```